### PR TITLE
DM-34621: Add .get method to Cache.

### DIFF
--- a/include/lsst/cpputils/Cache.h
+++ b/include/lsst/cpputils/Cache.h
@@ -23,6 +23,7 @@
 #define LSST_CPPUTILS_CACHE_H
 
 #include <vector>
+#include <optional>
 #include <utility>  // std::pair
 
 #include "boost/multi_index_container.hpp"
@@ -175,6 +176,23 @@ class Cache {
      * system in a valid but unpredictable state.
      */
     bool contains(Key const& key) { return _lookup(key).second; }
+
+    /** Return the cached value if it exists.
+     *
+     * If the key is in the cache, it will be promoted to the
+     * most recently used value.
+     *
+     * @exceptsafe Basic exception safety: exceptions will leave the
+     * system in a valid but unpredictable state.
+     */
+    std::optional<Value> get(Key const& key) {
+        auto result = _lookup(key);
+        if (result.second) {
+            return std::optional<Value>(result.first->second);
+        } else {
+            return std::optional<Value>();
+        }
+    }
 
     /** Return the capacity of the cache
      *

--- a/include/lsst/cpputils/python/Cache.h
+++ b/include/lsst/cpputils/python/Cache.h
@@ -49,6 +49,7 @@ void declareCache(py::module & mod, std::string const& name) {
                 return self(key, func);
             }, "key"_a, "func"_a);
     cls.def("__getitem__", &Class::operator[]);
+    cls.def("get", &Class::get);
     cls.def("add", &Class::add, "key"_a, "value"_a);
     cls.def("size", &Class::size);
     cls.def("__len__", &Class::size);

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -89,11 +89,13 @@ class CacheTestCase(unittest.TestCase):
         self.assertEqual(cache.capacity(), capacity, "Capacity unchanged")
         for ii in range(maximum - capacity):
             self.assertNotIn(ii, cache, "Should have been expunged")
+            self.assertIsNone(cache.get(ii), "Should have been expunged")
         expectedContents = list(range(maximum - 1, maximum - capacity - 1, -1))  # Last in, first out
         actualContents = cache.keys()
         for ii in expectedContents:
             self.assertIn(ii, cache, "Should be present")
             self.assertEqual(cache[ii], numberToWords(ii), "Value accessible and as expected")
+            self.assertEqual(cache.get(ii), numberToWords(ii), "Value accessible via get and as expected")
         self.assertListEqual(actualContents, expectedContents, "Contents are as expected")
         with self.assertRaises(LookupError):
             cache[maximum - capacity - 1]


### PR DESCRIPTION
This returns std::optional, which lets us do a single lookup and handle either case without using exceptions for control flow.