### PR TITLE
DM-22823: Remove accidental Doxygen comments for namespaces

### DIFF
--- a/include/lsst/cpputils/CacheFwd.h
+++ b/include/lsst/cpputils/CacheFwd.h
@@ -22,7 +22,7 @@
 #ifndef LSST_CPPUTILS_CACHE_FWD_H
 #define LSST_CPPUTILS_CACHE_FWD_H
 
-/** Forward declarations for lsst::cpputils::Cache
+/* Forward declarations for lsst::cpputils::Cache
  *
  * For details on the Cache class, see the Cache.h file.
  */


### PR DESCRIPTION
This PR removes a Doxygen comment block that was intended to document the file but instead documented `namespace lsst`.